### PR TITLE
Atomic を使った実装に変更

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,125 +1,93 @@
-use futures::future::FutureExt;
-use std::fmt;
+use serde::Serialize;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::task::{Poll, Context};
 use tokio::io::{Result, ErrorKind};
 use tokio::prelude::*;
-use tokio::sync::Mutex;
 
 use crate::item::Item;
 
-struct ProgressInner<T> {
+#[derive(Serialize, Debug)]
+pub struct Progress {
     name: String,
-    total: u64,
-    size: u64,
-    canceled: bool,
-    buf: T,
+    total: AtomicU64,
+    size: AtomicU64,
+    canceled: AtomicBool,
 }
 
-impl<T> fmt::Debug for ProgressInner<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProgressInner")
-            .field("name", &self.name)
-            .field("total", &self.total)
-            .field("size", &self.size)
-            .field("canceled", &self.canceled)
-            .finish()
-    }
-}
-
-pub struct Progress<T> {
-    inner: Arc<Mutex<ProgressInner<T>>>,
-}
-
-impl<T> std::clone::Clone for Progress<T> {
-    fn clone(&self) -> Self {
-        Progress { inner: self.inner.clone() }
-    }
-}
-
-impl<T> Progress<T> {
-    pub fn new(name: impl ToString, buf: T) -> Self {
-        let inner = Arc::new(Mutex::new(ProgressInner {
+impl Progress {
+    pub fn new(name: impl ToString) -> Arc<Self> {
+        Arc::new(Progress {
             name: name.to_string(),
-            total: 0,
-            size: 0,
-            canceled: false,
-            buf,
-        }));
-        Progress { inner }
+            total: 0.into(),
+            size: 0.into(),
+            canceled: false.into(),
+        })
     }
 
-    pub async fn set_total(&mut self, total: u64) {
-        self.inner.lock().await.total = total;
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::Release);
     }
 
-    pub async fn cancel(&mut self) {
-        self.inner.lock().await.canceled = true
-    }
-
-    pub async fn to_item(&self, id: impl ToString) -> Item {
-        let pg = self.inner.lock().await;
+    pub fn to_item(&self, id: impl ToString) -> Item {
         Item {
             id: id.to_string(),
-            name: pg.name.clone(),
-            total: pg.total,
-            size: pg.size,
-            canceled: pg.canceled,
+            name: self.name.clone(),
+            total: self.total.load(Ordering::Acquire),
+            size: self.size.load(Ordering::Acquire),
+            canceled: self.canceled.load(Ordering::Acquire),
         }
     }
 }
 
-impl<T: AsyncWrite + Unpin + Send> AsyncWrite for Progress<T> {
+pub struct ProgressWriter<T> {
+    pg: Arc<Progress>,
+    buf: T,
+}
+
+impl<T> ProgressWriter<T> {
+    pub fn new(pg: Arc<Progress>, buf: T) -> Self {
+        ProgressWriter {
+            pg,
+            buf,
+        }
+    }
+
+    pub fn set_total(&mut self, total: u64) {
+        self.pg.total.store(total, Ordering::Release);
+    }
+}
+
+impl<T: AsyncWrite + Unpin + Send> AsyncWrite for ProgressWriter<T> {
     fn poll_write(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context,
         buf: &[u8]
     ) -> Poll<Result<usize>> {
-        match self.inner.lock().boxed().as_mut().poll(cx) {
-            Poll::Ready(mut s) => {
-                if s.canceled {
-                    Poll::Ready(Err(io::Error::new(ErrorKind::Interrupted, "canceled")))
-                } else {
-                    let poll = Pin::new(&mut s.buf).poll_write(cx, buf);
-                    if let Poll::Ready(Ok(n)) = poll {
-                        s.size += n as u64;
-                    }
-                    poll
-                }
-            },
-            Poll::Pending => {
-                Poll::Pending
+        if self.pg.canceled.load(Ordering::Acquire) {
+            Poll::Ready(Err(io::Error::new(ErrorKind::Interrupted, "canceled")))
+        } else {
+            let poll = Pin::new(&mut self.buf).poll_write(cx, buf);
+            if let Poll::Ready(Ok(n)) = poll {
+                self.pg.size.fetch_add(n as u64, Ordering::Acquire);
             }
+            poll
         }
     }
 
     fn poll_flush(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context
     ) -> Poll<Result<()>> {
-        match self.inner.lock().boxed().as_mut().poll(cx) {
-            Poll::Ready(mut s) => {
-                Pin::new(&mut s.buf).poll_flush(cx)
-            },
-            Poll::Pending => {
-                Poll::Pending
-            }
-        }
+        Pin::new(&mut self.buf).poll_flush(cx)
     }
 
     fn poll_shutdown(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context
     ) -> Poll<Result<()>> {
-        match self.inner.lock().boxed().as_mut().poll(cx) {
-            Poll::Ready(mut s) => {
-                Pin::new(&mut s.buf).poll_shutdown(cx)
-            },
-            Poll::Pending => {
-                Poll::Pending
-            }
-        }
+        Pin::new(&mut self.buf).poll_shutdown(cx)
     }
 }
 
@@ -129,34 +97,33 @@ mod tests {
 
     use std::io::Cursor;
 
-    #[tokio::test]
-    async fn set_total_test() {
-        let mut pg = Progress::new("name", ());
-        assert_eq!(pg.to_item("").await.total, 0);
-        pg.set_total(1000).await;
-        assert_eq!(pg.to_item("").await.total, 1000);
+    #[test]
+    fn set_total_test() {
+        let mut writer = ProgressWriter::new(Progress::new("name"), ());
+        assert_eq!(writer.pg.to_item("").total, 0);
+        writer.set_total(1000);
+        assert_eq!(writer.pg.to_item("").total, 1000);
     }
 
-    #[tokio::test]
-    async fn cancel_test() {
-        let mut pg = Progress::new("name", ());
-        assert_eq!(pg.to_item("").await.canceled, false);
-        pg.cancel().await;
-        assert_eq!(pg.to_item("").await.canceled, true);
+    #[test]
+    fn cancel_test() {
+        let writer = ProgressWriter::new(Progress::new("name"), ());
+        assert_eq!(writer.pg.to_item("").canceled, false);
+        writer.pg.cancel();
+        assert_eq!(writer.pg.to_item("").canceled, true);
     }
 
-    #[tokio::test]
-    async fn to_item_test() {
-        let pg = Progress {
-            inner: Arc::new(Mutex::new(
-                ProgressInner {
-                    name: "name".to_string(),
-                    total: 1000,
-                    size: 200,
-                    canceled: true,
-                    buf: (),
-                }
-        ))};
+    #[test]
+    fn to_item_test() {
+        let writer = ProgressWriter {
+            pg: Arc::new(Progress {
+                name: "name".to_string(),
+                total: 1000.into(),
+                size: 200.into(),
+                canceled: true.into(),
+            }),
+            buf: (),
+        };
 
         let item = Item {
             id: "id".to_string(),
@@ -166,40 +133,40 @@ mod tests {
             canceled: true,
         };
 
-        assert_eq!(pg.to_item("id").await, item);
+        assert_eq!(writer.pg.to_item("id"), item);
     }
 
     #[tokio::test]
     async fn async_write_test() {
-        let mut pg = Progress::new("name", Cursor::new(vec![]));
+        let mut writer = ProgressWriter::new(Progress::new("name"), Cursor::new(vec![]));
         let buf = [0, 1, 2];
-        pg.write_all(&buf).await.unwrap();
-        assert_eq!(pg.inner.lock().await.buf.get_ref(), &vec![0, 1, 2]);
+        writer.write_all(&buf).await.unwrap();
+        assert_eq!(writer.buf.get_ref(), &vec![0, 1, 2]);
     }
 
     #[tokio::test]
     async fn progress_test() {
-        let mut pg = Progress::new("name", Cursor::new(vec![]));
+        let mut writer = ProgressWriter::new(Progress::new("name"), Cursor::new(vec![]));
         let mut buf = vec![0, 1, 2];
 
-        assert_eq!(pg.inner.lock().await.size, 0);
-        pg.write_all(&mut buf).await.unwrap();
-        assert_eq!(pg.inner.lock().await.size, 3);
-        pg.write_all(&mut buf).await.unwrap();
-        assert_eq!(pg.inner.lock().await.size, 6);
+        assert_eq!(writer.pg.size.load(Ordering::Acquire), 0);
+        writer.write_all(&mut buf).await.unwrap();
+        assert_eq!(writer.pg.size.load(Ordering::Acquire), 3);
+        writer.write_all(&mut buf).await.unwrap();
+        assert_eq!(writer.pg.size.load(Ordering::Acquire), 6);
     }
 
     #[tokio::test]
     async fn cancel_write_test() {
-        let mut pg = Progress::new("name", Cursor::new(vec![]));
+        let mut writer = ProgressWriter::new(Progress::new("name"), Cursor::new(vec![]));
         let mut buf = vec![0, 1, 2];
 
-        assert_eq!(pg.inner.lock().await.canceled, false);
-        assert!(pg.write_all(&mut buf).await.is_ok());
+        assert_eq!(writer.pg.canceled.load(Ordering::Acquire), false);
+        assert!(writer.write_all(&mut buf).await.is_ok());
 
-        pg.cancel().await;
+        writer.pg.cancel();
 
-        assert_eq!(pg.inner.lock().await.canceled, true);
-        assert!(pg.write_all(&mut buf).await.is_err());
+        assert_eq!(writer.pg.canceled.load(Ordering::Acquire), true);
+        assert!(writer.write_all(&mut buf).await.is_err());
     }
 }


### PR DESCRIPTION
close #34 

https://teratail.com/questions/258513

teratail でいくつかの解決方法を教えてもらった。

1. Mutex の Future を保存する
2. Atomic 型を使う
3. tokio::sync::watch を使う

1 は unsafe で扱いが難しいためできれば避けたい
3 は broadcast の際に item のコピーが発生するためコストが比較的高く見える。( 気にするほどではないかもしれないけど )

現在、更新が必要なフィールドは Atomic 型が用意されている型だけのため、 2 を採用する。

今後 Progress に更新する必要がある Atomic ではない型を持たせたくなった時は 3 を採用する。

## 常に SeqCst にしている理由

> とは言うものの、実際は挙動のわかりやすさを重視して常に memory_order_seq_cst を使うべきでしょう。マルチスレッドのバグは分かりにくく、再現性も乏しいことが多いので、よほどのことがない限り安全側に寄せたコードを書いたほうが良いと思います。
> https://yamasa.hatenablog.jp/entry/20090816/1250446250

`load` は `Ordering::Acquire` 、 `store` は `Ordering::Release` を使っても問題は発生しなかったが、今後これに起因するバグが発生する方がコストが高いと判断した。